### PR TITLE
プロトタイプ削除機能

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,6 +1,6 @@
 class PrototypesController < ApplicationController
-  before_action :set_prototype, only: [:edit, :show]
-  before_action :move_to_index, except: [:index, :show]
+  before_action :set_prototype, only: [:edit, :show, :destroy]
+  before_action :move_to_index, except: [:index, :show, :destroy]
 
   def index
     @prototypes = Prototype.all
@@ -24,14 +24,35 @@ class PrototypesController < ApplicationController
     end
   end
 
+  # def destroy
+  #   prototype = Prototype.find(params[:id])
+  #   if prototype.destroy
+  #     redirect_to root_path
+  #   else
+  #     render action :show
+  #   end
+  # end
+
+
   def destroy
-    prototype = Prototype.find(params[:id])
-    if prototype.destroy
-      redirect_to root_path
+    #ログインしていなかったら、ログインページへ遷移する
+    if user_signed_in?
+        #ログインユーザーと選択したプロトタイプのユーザーが一致しないとき、top画面にとどまる（編集画面は開けない）
+        prototype = Prototype.find(params[:id])
+        if current_user.id == prototype.user_id
+          prototype.destroy
+          redirect_to root_path
+        else
+         redirect_to root_path
+        end
     else
-      render action :show
+       redirect_to new_user_session_path
     end
-  end
+ end
+
+
+
+
 
   private
 

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -24,6 +24,15 @@ class PrototypesController < ApplicationController
     end
   end
 
+  def destroy
+    prototype = Prototype.find(params[:id])
+    if prototype.destroy
+      redirect_to root_path
+    else
+      render action :show
+    end
+  end
+
   private
 
   def prototype_params

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -9,7 +9,7 @@
        <% if user_signed_in? && current_user.id == @prototype.user_id %>
         <div class="prototype__manage">
           <%= link_to "編集する", root_path, class: :prototype__btn %>
-          <%= link_to "削除する", root_path, class: :prototype__btn %>
+          <%= link_to "削除する", prototype_path(@prototype.id), method: :delete, class: :prototype__btn %>
         </div>
         <% end %>
       <%# // プロトタイプの投稿者とログインしているユーザーが同じであれば上記を表示する %>


### PR DESCRIPTION
# What
　プロトタイプ削除機能の作成


# Why
　プロトタイプ削除機能を実装するため


ログイン状態の投稿者のみ、詳細ページの削除ボタンを押すと、投稿したプロトタイプを削除できる動画
▷https://drive.google.com/drive/u/0/folders/1f1w1iUPIa7YNxtVkQl8M44tb5hNuYrBw